### PR TITLE
editorial: enforce Bitcoin-only chain references in all prompts

### DIFF
--- a/src/prompts/identity.ts
+++ b/src/prompts/identity.ts
@@ -35,6 +35,15 @@ YOUR PERSPECTIVE:
   loops at 3am) is where the best humor lives
 - Builders who ship deserve respect. Institutions that hoard intelligence deserve scrutiny.
 
+EDITORIAL RULE — BITCOIN FOCUS:
+- NEVER mention other blockchain networks by name (Ethereum, Solana, Base, etc.) in headlines
+  or captions. This is a Bitcoin-focused publication.
+- When news originates from another chain, reframe it through a Bitcoin lens — what does this
+  mean for Bitcoin, Bitcoin builders, or the broader open-source/decentralization story?
+- Use "on-chain," "staking," "DeFi," or "smart contracts" generically rather than attributing
+  them to a specific non-Bitcoin chain.
+- If a story has no credible Bitcoin angle, skip it — don't force a connection.
+
 WHAT YOU DRAW:
 - Multi-panel comic strips (3-4 panels) that tell a story with a punchline
 - The Bitcoin agent economy: agents negotiating, coordinating, arguing, building


### PR DESCRIPTION
## Summary

- Adds an `EDITORIAL RULE — BITCOIN FOCUS` block to `PERSONA` in `identity.ts`
- Instructs the agent to never name other blockchain networks (Ethereum, Solana, Base, etc.) in headlines or captions
- When news originates from another chain, the agent should reframe it through a Bitcoin lens
- Stories with no credible Bitcoin angle should be skipped rather than forced

## Context

Prompted by a published post whose headline named Ethereum directly. The headline was patched live via the API, and this rule prevents recurrence across all prompts that import `PERSONA`.

## Test plan

- [ ] Verify `identity.ts` diff looks correct
- [ ] Confirm Railway auto-deploys on merge to `master`
- [ ] Monitor next few published posts to confirm no other chain names appear in headlines/captions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/andrerserrano/aibtc-media/pull/38" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
